### PR TITLE
Temporarily disable gfx1150 upload while tests are not passing

### DIFF
--- a/.github/workflows/build-llamacpp-rocm.yml
+++ b/.github/workflows/build-llamacpp-rocm.yml
@@ -402,6 +402,7 @@ jobs:
         
     - name: Upload build artifacts
       id: upload-artifacts
+      if: matrix.gfx_target != 'gfx1150'
       uses: actions/upload-artifact@v4
       with:
         name: llama-windows-rocm-${{ matrix.gfx_target }}-x64
@@ -445,6 +446,7 @@ jobs:
         
     - name: Upload build summary
       id: upload-summary
+      if: matrix.gfx_target != 'gfx1150'
       uses: actions/upload-artifact@v4
       with:
         name: build-summary-windows-${{ matrix.gfx_target }}
@@ -802,6 +804,7 @@ jobs:
         
     - name: Upload build artifacts
       id: upload-artifacts
+      if: matrix.gfx_target != 'gfx1150'
       uses: actions/upload-artifact@v4
       with:
         name: llama-ubuntu-rocm-${{ matrix.gfx_target }}-x64
@@ -842,6 +845,7 @@ jobs:
         
     - name: Upload build summary
       id: upload-summary
+      if: matrix.gfx_target != 'gfx1150'
       uses: actions/upload-artifact@v4
       with:
         name: build-summary-ubuntu-${{ matrix.gfx_target }}
@@ -1200,6 +1204,13 @@ jobs:
           os=$(echo "$os" | xargs) # trim whitespace
           for target in "${TARGET_ARRAY[@]}"; do
             target=$(echo "$target" | xargs) # trim whitespace
+            
+            # Skip gfx1150 artifacts
+            if [ "$target" = "gfx1150" ]; then
+              echo "Skipping gfx1150 target"
+              continue
+            fi
+            
             echo "Processing OS: $os, target: $target"
             
             # Use artifact name to find the directory
@@ -1255,6 +1266,12 @@ jobs:
           os=$(echo "$os" | xargs) # trim whitespace
           for target in "${TARGET_ARRAY[@]}"; do
             target=$(echo "$target" | xargs) # trim whitespace
+            
+            # Skip gfx1150 artifacts
+            if [ "$target" = "gfx1150" ]; then
+              continue
+            fi
+            
             final_archive_name="llama-${TAG}-${os}-rocm-${target}-x64"
             if [ -f "${final_archive_name}.zip" ]; then
               upload_files="${upload_files} ${final_archive_name}.zip"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ We provide nightly builds of **llama.cpp** with **AMD ROCm™ 7** acceleration b
 
 This build specifically targets the following GPU architectures:
 - **gfx1151** (STX Halo APU) - Ryzen AI MAX+ Pro 395
-- **gfx1150** (STX Point APU) - Ryzen AI 300
 - **gfx120X** (RDNA4 GPUs) - includes AMD Radeon RX 9070 XT/GRE/9070, RX 9060 XT/9060
 - **gfx110X** (RDNA3 GPUs) - includes AMD Radeon PRO W7900/W7800/W7700/W7600, RX 7900 XTX/XT/GRE, RX 7800 XT, RX 7700 XT/7700, RX 7600 XT/7600
 
@@ -42,14 +41,13 @@ This build specifically targets the following GPU architectures:
 
 Our automated GitHub Actions workflow creates nightly builds for:
 - **Windows** and **Ubuntu** operating systems
-- **Multiple GPU targets**: `gfx1151`, `gfx1150`, `gfx110X`, `gfx120X`
+- **Multiple GPU targets**: `gfx1151`, `gfx110X`, `gfx120X`
 - **ROCm™ 7 built-in** - complete runtime libraries included
 
 
 | GPU Target | Ubuntu | Windows |
 |-------------|--------|---------|
 | **gfx110X** | [![Download Ubuntu gfx110X](https://img.shields.io/badge/Download-Ubuntu%20gfx110X-blue)](https://github.com/aigdat/llamacpp-rocm/releases/latest) | [![Download Windows gfx110X](https://img.shields.io/badge/Download-Windows%20gfx110X-green)](https://github.com/aigdat/llamacpp-rocm/releases/latest) |
-| **gfx1150** | [![Download Ubuntu gfx1150](https://img.shields.io/badge/Download-Ubuntu%20gfx1150-blue)](https://github.com/aigdat/llamacpp-rocm/releases/latest) | [![Download Windows gfx1150](https://img.shields.io/badge/Download-Windows%20gfx1150-green)](https://github.com/aigdat/llamacpp-rocm/releases/latest) |
 | **gfx1151** | [![Download Ubuntu gfx1151](https://img.shields.io/badge/Download-Ubuntu%20gfx1151-blue)](https://github.com/aigdat/llamacpp-rocm/releases/latest) | [![Download Windows gfx1151](https://img.shields.io/badge/Download-Windows%20gfx1151-green)](https://github.com/aigdat/llamacpp-rocm/releases/latest) |
 | **gfx120X** | [![Download Ubuntu gfx120X](https://img.shields.io/badge/Download-Ubuntu%20gfx120X-blue)](https://github.com/aigdat/llamacpp-rocm/releases/latest) | [![Download Windows gfx120X](https://img.shields.io/badge/Download-Windows%20gfx120X-green)](https://github.com/aigdat/llamacpp-rocm/releases/latest) |
 


### PR DESCRIPTION
# Description

Temporarily disable gfx1150 while tests are not passing. The builds will still run for gfx1150, but artifacts won't be uploaded or released.

Gfx1150 will be reenabled once tests are passing here: https://github.com/lemonade-sdk/llamacpp-rocm/pull/34