### PR TITLE
Disable linux testing

### DIFF
--- a/.github/workflows/build-llamacpp-rocm.yml
+++ b/.github/workflows/build-llamacpp-rocm.yml
@@ -892,10 +892,7 @@ jobs:
             gfx_target: gfx1151
             artifact_prefix: windows
             runner: ["stx-halo", "Windows"]
-          - os: Linux
-            gfx_target: gfx1151
-            artifact_prefix: ubuntu
-            runner: ["stx-halo", "Linux"]
+          # Linux testing for gfx1151 is disabled
       fail-fast: false
 
     steps:


### PR DESCRIPTION
This PR temporarily disables linux testing on gfx1151 to unblock the release process.