### PR TITLE
Add RPC server support for distributed inference

### DIFF
--- a/.github/workflows/build-llamacpp-rocm.yml
+++ b/.github/workflows/build-llamacpp-rocm.yml
@@ -313,7 +313,7 @@ jobs:
           -DGGML_OPENMP=OFF ^
           -DGGML_CUDA_FORCE_CUBLAS=OFF ^
           -DGGML_RPC=ON ^
-          -DGGML_HIP_ROCWMMA_FATTN=OFF
+          -DGGML_HIP_ROCWMMA_FATTN=OFF ^
           -DLLAMA_CURL=OFF ^
           -DGGML_NATIVE=OFF ^
           -DGGML_STATIC=OFF ^


### PR DESCRIPTION
# Description

Enable -DGGML_RPC=ON in CMake configuration for both Windows and Ubuntu builds.

This adds the rpc-server binary to the release artifacts, allowing users to distribute large model inference across multiple machines with different GPUs.