### PR TITLE
Avoid excessive unroll -  Set unroll threshold to HIP compile flags

### DIFF
--- a/.github/workflows/build-llamacpp-rocm.yml
+++ b/.github/workflows/build-llamacpp-rocm.yml
@@ -304,6 +304,7 @@ jobs:
           -DCMAKE_C_COMPILER="C:\opt\rocm\lib\llvm\bin\clang.exe" ^
           -DCMAKE_CXX_COMPILER="C:\opt\rocm\lib\llvm\bin\clang++.exe" ^
           -DCMAKE_CXX_FLAGS="-IC:\opt\rocm\include" ^
+          -DCMAKE_HIP_FLAGS="-mllvm --amdgpu-unroll-threshold-local=600" ^
           -DCMAKE_CROSSCOMPILING=ON ^
           -DCMAKE_BUILD_TYPE=Release ^
           -DGPU_TARGETS="%mapped_target%" ^
@@ -713,6 +714,7 @@ jobs:
           -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
           -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
           -DCMAKE_CXX_FLAGS="-I/opt/rocm/include" \
+          -DCMAKE_HIP_FLAGS="-mllvm --amdgpu-unroll-threshold-local=600" \
           -DCMAKE_CROSSCOMPILING=ON \
           -DCMAKE_BUILD_TYPE=Release \
           -DGPU_TARGETS="$mapped_target" \


### PR DESCRIPTION
TheRock's compiler stack is still pinned at `ROCm/TheRock@9c7ac0f`, which means nightly builds don't include the LLVM unroll-threshold revert from `ROCm/llvm-project#1349`. Without that revert, some HIP kernels in llama.cpp over-unroll and produce broken builds.

This adds `-DCMAKE_HIP_FLAGS="-mllvm --amdgpu-unroll-threshold-local=600"` to the cmake configure step on both Windows and Linux, matching the workaround used upstream in `ggml-org/llama.cpp#19433`.


This PR can be removed/reverted once TheRock bumps its compiler stack past the revert.