### PR TITLE
 Add SSL-related compile option

### DIFF
--- a/.github/workflows/build-llamacpp-rocm.yml
+++ b/.github/workflows/build-llamacpp-rocm.yml
@@ -314,7 +314,7 @@ jobs:
           -DGGML_CUDA_FORCE_CUBLAS=OFF ^
           -DGGML_RPC=ON ^
           -DGGML_HIP_ROCWMMA_FATTN=OFF ^
-          -DLLAMA_CURL=OFF ^
+          -DLLAMA_BUILD_BORINGSSL=ON ^
           -DGGML_NATIVE=OFF ^
           -DGGML_STATIC=OFF ^
           -DCMAKE_SYSTEM_NAME=Windows
@@ -723,7 +723,7 @@ jobs:
           -DGGML_CUDA_FORCE_CUBLAS=OFF \
           -DGGML_RPC=ON \
           -DGGML_HIP_ROCWMMA_FATTN=OFF \
-          -DLLAMA_CURL=OFF \
+          -DLLAMA_BUILD_BORINGSSL=ON \
           -DGGML_NATIVE=OFF \
           -DGGML_STATIC=OFF \
           -DCMAKE_SYSTEM_NAME=Linux


### PR DESCRIPTION
This is a PR corresponding to #62.
Turn on the LLAMA_BUILD_BORINGSSL flag.
Since BoringSSL will be downloaded during the build process, in build-llamacpp-rocm.yml it is sufficient to simply enable the flag.

I verified that the build succeeds for all entries in the build matrix.
Since my available environment is gfx1151 / Windows, actual runtime testing was performed only on gfx1151 systems running Windows and Ubuntu (WSL2 + librocdxg).
For both Windows and Ubuntu, I confirmed that models can be downloaded from Hugging Face and executed using the -hf option.
