### PR TITLE
Enable LTO to all targets, and apply gfx1151 specific configurations

### DIFF
--- a/.github/workflows/build-llamacpp-rocm.yml
+++ b/.github/workflows/build-llamacpp-rocm.yml
@@ -724,7 +724,7 @@ jobs:
           -DBUILD_SHARED_LIBS=ON \
           -DLLAMA_BUILD_TESTS=OFF \
           -DGGML_HIP=ON \
-          -DGGML_OPENMP=OFF \
+          -DGGML_OPENMP=ON \
           -DGGML_CUDA_FORCE_CUBLAS=OFF \
           -DGGML_RPC=ON \
           -DGGML_HIP_ROCWMMA_FATTN=OFF \

--- a/.github/workflows/build-llamacpp-rocm.yml
+++ b/.github/workflows/build-llamacpp-rocm.yml
@@ -713,6 +713,15 @@ jobs:
         mkdir build
         cd build
 
+        if [ "$current_target" = "gfx1151" ]; then
+          EXTRA_CMAKE_ARGS = \
+            -DGGML_OPENMP=ON \
+            -DGGML_HIP_NO_VMM=ON
+        else
+          EXTRA_CMAKE_ARGS = \
+            -DGGML_OPENMP=OFF
+        fi
+
         # Configure the project
         cmake .. -G Ninja \
           -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
@@ -724,14 +733,15 @@ jobs:
           -DBUILD_SHARED_LIBS=ON \
           -DLLAMA_BUILD_TESTS=OFF \
           -DGGML_HIP=ON \
-          -DGGML_OPENMP=OFF \
+          -DGGML_LTO=ON \
           -DGGML_CUDA_FORCE_CUBLAS=OFF \
           -DGGML_RPC=ON \
           -DGGML_HIP_ROCWMMA_FATTN=OFF \
           -DLLAMA_BUILD_BORINGSSL=ON \
           -DGGML_NATIVE=OFF \
           -DGGML_STATIC=OFF \
-          -DCMAKE_SYSTEM_NAME=Linux
+          -DCMAKE_SYSTEM_NAME=Linux \
+          $EXTRA_CMAKE_ARGS
 
         # Build the project
         cmake --build . -j $(nproc)


### PR DESCRIPTION
llama-bench shows 15%-20% gain in token generation on gfx1151 when applying these specific llamacpp build configs.

These are benchmarks with this patch:
$ GGML_CUDA_ENABLE_UNIFIED_MEMORY=1 LD_LIBRARY_PATH=. ./llama-bench -hf unsloth/Qwen3-Coder-Next-GGUF:UD-Q5_K_XL -fa 0,1 --mmap 0,1 -ngl 99 ggml_cuda_init: found 1 ROCm devices (Total VRAM: 64042 MiB):
  Device 0: Radeon 8060S Graphics, gfx1151 (0x1151), VMM: no, Wave Size: 32, VRAM: 64042 MiB
| model                          |       size |     params | backend    | ngl | fa | mmap |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -: | ---: | --------------: | -------------------: |
| qwen3next 80B.A3B Q5_K - Medium |  55.45 GiB |    79.67 B | ROCm       |  99 |  0 |    0 |           pp512 |        617.84 ± 4.64 |
| qwen3next 80B.A3B Q5_K - Medium |  55.45 GiB |    79.67 B | ROCm       |  99 |  0 |    0 |           tg128 |         39.22 ± 0.02 |
| qwen3next 80B.A3B Q5_K - Medium |  55.45 GiB |    79.67 B | ROCm       |  99 |  1 |    0 |           pp512 |        612.25 ± 5.97 |
| qwen3next 80B.A3B Q5_K - Medium |  55.45 GiB |    79.67 B | ROCm       |  99 |  1 |    0 |           tg128 |         39.57 ± 0.03 |
| qwen3next 80B.A3B Q5_K - Medium |  55.45 GiB |    79.67 B | ROCm       |  99 |  0 |    1 |           pp512 |       558.94 ± 97.46 |
| qwen3next 80B.A3B Q5_K - Medium |  55.45 GiB |    79.67 B | ROCm       |  99 |  0 |    1 |           tg128 |         37.77 ± 0.16 |
| qwen3next 80B.A3B Q5_K - Medium |  55.45 GiB |    79.67 B | ROCm       |  99 |  1 |    1 |           pp512 |        618.13 ± 7.40 |
| qwen3next 80B.A3B Q5_K - Medium |  55.45 GiB |    79.67 B | ROCm       |  99 |  1 |    1 |           tg128 |         38.13 ± 0.05 |

These are benchmarks before the patch:
$ GGML_CUDA_ENABLE_UNIFIED_MEMORY=1 LD_LIBRARY_PATH=. ./llama-bench -hf unsloth/Qwen3-Coder-Next-GGUF:UD-Q5_K_XL -fa 0,1 --mmap 0,1 -ngl 99 ggml_cuda_init: found 1 ROCm devices (Total VRAM: 64042 MiB):
  Device 0: Radeon 8060S Graphics, gfx1151 (0x1151), VMM: no, Wave Size: 32, VRAM: 64042 MiB
| model                          |       size |     params | backend    | ngl | fa | mmap |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -: | ---: | --------------: | -------------------: |
| qwen3next 80B.A3B Q5_K - Medium |  55.45 GiB |    79.67 B | ROCm       |  99 |  0 |    0 |           pp512 |       600.81 ± 20.08 |
| qwen3next 80B.A3B Q5_K - Medium |  55.45 GiB |    79.67 B | ROCm       |  99 |  0 |    0 |           tg128 |         32.85 ± 0.35 |
| qwen3next 80B.A3B Q5_K - Medium |  55.45 GiB |    79.67 B | ROCm       |  99 |  1 |    0 |           pp512 |       605.97 ± 12.16 |
| qwen3next 80B.A3B Q5_K - Medium |  55.45 GiB |    79.67 B | ROCm       |  99 |  1 |    0 |           tg128 |         33.27 ± 0.37 |
| qwen3next 80B.A3B Q5_K - Medium |  55.45 GiB |    79.67 B | ROCm       |  99 |  0 |    1 |           pp512 |        607.84 ± 9.18 |
| qwen3next 80B.A3B Q5_K - Medium |  55.45 GiB |    79.67 B | ROCm       |  99 |  0 |    1 |           tg128 |         32.47 ± 0.05 |
| qwen3next 80B.A3B Q5_K - Medium |  55.45 GiB |    79.67 B | ROCm       |  99 |  1 |    1 |           pp512 |       618.88 ± 13.58 |
| qwen3next 80B.A3B Q5_K - Medium |  55.45 GiB |    79.67 B | ROCm       |  99 |  1 |    1 |           tg128 |         33.10 ± 0.06 |