### PR TITLE
Add -DGGML_HIP_NO_VMM=OFF to fix ROCm OOM/segfault on APUs and RDNA 3.5+

### DIFF
--- a/.github/workflows/build-llamacpp-rocm.yml
+++ b/.github/workflows/build-llamacpp-rocm.yml
@@ -312,6 +312,7 @@ jobs:
           -DBUILD_SHARED_LIBS=ON ^
           -DLLAMA_BUILD_TESTS=OFF ^
           -DGGML_HIP=ON ^
+          -DGGML_USE_VMM=ON ^
           -DGGML_OPENMP=OFF ^
           -DGGML_CUDA_FORCE_CUBLAS=OFF ^
           -DGGML_RPC=ON ^
@@ -724,6 +725,7 @@ jobs:
           -DBUILD_SHARED_LIBS=ON \
           -DLLAMA_BUILD_TESTS=OFF \
           -DGGML_HIP=ON \
+          -DGGML_USE_VMM=ON \
           -DGGML_OPENMP=OFF \
           -DGGML_CUDA_FORCE_CUBLAS=OFF \
           -DGGML_RPC=ON \

--- a/.github/workflows/build-llamacpp-rocm.yml
+++ b/.github/workflows/build-llamacpp-rocm.yml
@@ -312,7 +312,7 @@ jobs:
           -DBUILD_SHARED_LIBS=ON ^
           -DLLAMA_BUILD_TESTS=OFF ^
           -DGGML_HIP=ON ^
-          -DGGML_USE_VMM=ON ^
+          -DGGML_HIP_NO_VMM=OFF ^
           -DGGML_OPENMP=OFF ^
           -DGGML_CUDA_FORCE_CUBLAS=OFF ^
           -DGGML_RPC=ON ^
@@ -725,7 +725,7 @@ jobs:
           -DBUILD_SHARED_LIBS=ON \
           -DLLAMA_BUILD_TESTS=OFF \
           -DGGML_HIP=ON \
-          -DGGML_USE_VMM=ON \
+          -DGGML_HIP_NO_VMM=OFF \
           -DGGML_OPENMP=OFF \
           -DGGML_CUDA_FORCE_CUBLAS=OFF \
           -DGGML_RPC=ON \


### PR DESCRIPTION
## Problem

All current builds report `VMM: no` because llama.cpp defaults `GGML_HIP_NO_VMM` to `ON` in `ggml/CMakeLists.txt`:

```
option(GGML_HIP_NO_VMM "ggml: do not try to use HIP VMM" ON)
```

Without VMM, `hipMalloc` never releases GPU memory pages. On unified-memory APUs (gfx1103/780M) and RDNA 3.5/4 dGPUs, the allocator permanently holds flash-attn scratch and KV cache memory, eventually OOMing and segfaulting (exit 139).

This is the root cause of #87, #79, #86, #52.

## Fix

Add `-DGGML_HIP_NO_VMM=OFF` to both the Windows and Ubuntu cmake configure steps. This enables the VMM-backed pool allocator (`ggml_cuda_pool_vmm`) which uses `hipMemCreate`/`hipMemMap` for on-demand allocation and `hipMemRelease` to return pages.

Note: The correct cmake flag is `GGML_HIP_NO_VMM`, not `GGML_USE_VMM` (which doesn't exist) or `GGML_CUDA_NO_VMM` (which only applies to CUDA builds). HIP VMM is controlled separately in `ggml/src/ggml-hip/CMakeLists.txt` and `ggml/src/ggml-cuda/common.cuh`.

## Safety

Devices that don't support VMM fall back to the legacy `hipMalloc` pool automatically at runtime via `hipDeviceAttributeVirtualMemoryManagementSupported`. No behavior change for unsupported hardware.

## Change

Two one-line additions to `.github/workflows/build-llamacpp-rocm.yml`:
- Windows cmake block: `-DGGML_HIP_NO_VMM=OFF ^`
- Ubuntu cmake block: `-DGGML_HIP_NO_VMM=OFF \`