### PR TITLE
Add gfx1152 support

### DIFF
--- a/.github/workflows/build-llamacpp-rocm.yml
+++ b/.github/workflows/build-llamacpp-rocm.yml
@@ -9,7 +9,7 @@ on:
       gfx_target:
         description: 'AMD GPU targets (comma-separated)'
         required: false
-        default: 'gfx1151,gfx1150,gfx120X,gfx110X,gfx103X'
+        default: 'gfx1151,gfx1152,gfx1150,gfx120X,gfx110X,gfx103X'
       rocm_version:
         description: 'ROCm version to use (e.g., 7.13.0a20260318) or "latest" to auto-detect'
         required: false
@@ -36,7 +36,7 @@ on:
 
 env:
   OPERATING_SYSTEMS: ${{ github.event.inputs.operating_systems || 'windows,ubuntu' }}
-  GFX_TARGETS: ${{ github.event.inputs.gfx_target || 'gfx1151,gfx1150,gfx120X,gfx110X,gfx103X' }}
+  GFX_TARGETS: ${{ github.event.inputs.gfx_target || 'gfx1151,gfx1152,gfx1150,gfx120X,gfx110X,gfx103X' }}
   ROCM_VERSION: ${{ github.event.inputs.rocm_version || 'latest' }}
   LLAMACPP_VERSION: ${{ github.event.inputs.llamacpp_version || 'latest' }}
 
@@ -277,6 +277,8 @@ jobs:
           set "mapped_target=gfx1030;gfx1031;gfx1032;gfx1034"
         ) else if "%current_target%"=="gfx1151" (
           set "mapped_target=gfx1151"
+        ) else if "%current_target%"=="gfx1152" (
+          set "mapped_target=gfx1152"
         ) else if "%current_target%"=="gfx1150" (
           set "mapped_target=gfx1150"
         ) else if "%current_target%"=="gfx120X" (
@@ -699,6 +701,8 @@ jobs:
           mapped_target="gfx1030;gfx1031;gfx1032;gfx1034"
         elif [ "$current_target" = "gfx1151" ]; then
           mapped_target="gfx1151"
+        elif [ "$current_target" = "gfx1152" ]; then
+          mapped_target="gfx1152"
         elif [ "$current_target" = "gfx1150" ]; then
           mapped_target="gfx1150"
         elif [ "$current_target" = "gfx120X" ]; then

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <img src="https://img.shields.io/badge/OS-Windows%20%7C%20Ubuntu-0078D6?logo=windows&logoColor=white" alt="Platform: Windows | Ubuntu" />
 </a>
 <a href="#-supported-devices" title="GPU targets">
-  <img src="https://img.shields.io/badge/GPU-gfx110X%20%7Cgfx1150%20%7C%20gfx1151%20%7C%20gfx120X%20%7C%20gfx103X-00B04F?logo=amd&logoColor=white" alt="GPU Targets" />
+  <img src="https://img.shields.io/badge/GPU-gfx110X%20%7C%20gfx1150%20%7C%20gfx1151%20%7C%20gfx1152%20%7C%20gfx120X%20%7C%20gfx103X-00B04F?logo=amd&logoColor=white" alt="GPU Targets" />
 </a>
 
 
@@ -32,7 +32,8 @@ We provide nightly builds of **llama.cpp** with **AMD ROCm™ 7** acceleration b
 
 This build specifically targets the following GPU architectures:
 - **gfx1151** (STX Halo APU) - Ryzen AI MAX+ Pro 395
-- **gfx1150** (STX Point APU) - Ryzen AI 300
+- **gfx1150** (STX Point APU) - Ryzen AI 9 HX 370 / Ryzen AI 9 365
+- **gfx1152** (Krackan Point APU) - Ryzen AI 7 350 / Ryzen AI 5 340 (Radeon 860M/840M iGPU)
 - **gfx120X** (RDNA4 GPUs) - includes AMD Radeon RX 9070 XT/GRE/9070, RX 9060 XT/9060
 - **gfx110X** (RDNA3 GPUs) - includes AMD Radeon dGPUs: PRO W7900/W7800/W7700/W7600, RX 7900 XTX/XT/GRE, RX 7800 XT, RX 7700 XT/7700, RX 7600 XT/7600 and iGPUs: Radeon 780M/760M/740M
 - **gfx103X** (RDNA2 GPUs) - includes AMD Radeon dGPUs: RX 6800 XT/6800, RX 6700 XT/6700, RX 6600 XT/6600, RX 6500 XT/6500
@@ -43,7 +44,7 @@ This build specifically targets the following GPU architectures:
 
 Our automated GitHub Actions workflow creates nightly builds for:
 - **Windows** and **Ubuntu** operating systems
-- **Multiple GPU targets**: `gfx1151`, `gfx1150`, `gfx110X`, `gfx120X`, `gfx103X`
+- **Multiple GPU targets**: `gfx1151`, `gfx1152`, `gfx1150`, `gfx110X`, `gfx120X`, `gfx103X`
 - **ROCm™ 7 built-in** - complete runtime libraries included
 
 
@@ -52,6 +53,7 @@ Our automated GitHub Actions workflow creates nightly builds for:
 | **gfx110X** | [![Download Ubuntu gfx110X](https://img.shields.io/badge/Download-Ubuntu%20gfx110X-blue)](https://github.com/aigdat/llamacpp-rocm/releases/latest) | [![Download Windows gfx110X](https://img.shields.io/badge/Download-Windows%20gfx110X-green)](https://github.com/aigdat/llamacpp-rocm/releases/latest) |
 | **gfx1150** | [![Download Ubuntu gfx1150](https://img.shields.io/badge/Download-Ubuntu%20gfx1150-blue)](https://github.com/aigdat/llamacpp-rocm/releases/latest) | [![Download Windows gfx1150](https://img.shields.io/badge/Download-Windows%20gfx1150-green)](https://github.com/aigdat/llamacpp-rocm/releases/latest) |
 | **gfx1151** | [![Download Ubuntu gfx1151](https://img.shields.io/badge/Download-Ubuntu%20gfx1151-blue)](https://github.com/aigdat/llamacpp-rocm/releases/latest) | [![Download Windows gfx1151](https://img.shields.io/badge/Download-Windows%20gfx1151-green)](https://github.com/aigdat/llamacpp-rocm/releases/latest) |
+| **gfx1152** | [![Download Ubuntu gfx1152](https://img.shields.io/badge/Download-Ubuntu%20gfx1152-blue)](https://github.com/aigdat/llamacpp-rocm/releases/latest) | [![Download Windows gfx1152](https://img.shields.io/badge/Download-Windows%20gfx1152-green)](https://github.com/aigdat/llamacpp-rocm/releases/latest) |
 | **gfx120X** | [![Download Ubuntu gfx120X](https://img.shields.io/badge/Download-Ubuntu%20gfx120X-blue)](https://github.com/aigdat/llamacpp-rocm/releases/latest) | [![Download Windows gfx120X](https://img.shields.io/badge/Download-Windows%20gfx120X-green)](https://github.com/aigdat/llamacpp-rocm/releases/latest) |
 | **gfx103X** | [![Download Ubuntu gfx103X](https://img.shields.io/badge/Download-Ubuntu%20gfx103X-blue)](https://github.com/aigdat/llamacpp-rocm/releases/latest) | [![Download Windows gfx103X](https://img.shields.io/badge/Download-Windows%20gfx103X-green)](https://github.com/aigdat/llamacpp-rocm/releases/latest) |
 

--- a/docs/manual_instructions.md
+++ b/docs/manual_instructions.md
@@ -184,7 +184,7 @@ When building llama.cpp with ROCm, the `-DGPU_TARGETS` parameter must be set bas
 - **`gfx103X`** maps to `gfx1030, gfx1031, gfx1032, gfx1034` (RDNA2 dGPU series like: RX 6800 XT/6800, RX 6700 XT/6700, RX 6600 XT/6600, RX 6500 XT/6500)
 - **`gfx1150`** remains as `gfx1150` (Strix Point)
 - **`gfx1151`** remains as `gfx1151` (Strix Halo)
-- **`gfx1152`** remains as `gfx1152` (Krackan Point - Radeon 860M/840M iGPUs in Ryzen AI 300 series)
+- **`gfx1152`** remains as `gfx1152` (Krackan Point)
 
 For a complete list of GPU targets and their mappings, see the [automated workflow](../.github/workflows/build-llamacpp-rocm.yml).
 

--- a/docs/manual_instructions.md
+++ b/docs/manual_instructions.md
@@ -184,6 +184,7 @@ When building llama.cpp with ROCm, the `-DGPU_TARGETS` parameter must be set bas
 - **`gfx103X`** maps to `gfx1030, gfx1031, gfx1032, gfx1034` (RDNA2 dGPU series like: RX 6800 XT/6800, RX 6700 XT/6700, RX 6600 XT/6600, RX 6500 XT/6500)
 - **`gfx1150`** remains as `gfx1150` (Strix Point)
 - **`gfx1151`** remains as `gfx1151` (Strix Halo)
+- **`gfx1152`** remains as `gfx1152` (Krackan Point - Radeon 860M/840M iGPUs in Ryzen AI 300 series)
 
 For a complete list of GPU targets and their mappings, see the [automated workflow](../.github/workflows/build-llamacpp-rocm.yml).
 
@@ -209,5 +210,8 @@ Replace the `-DGPU_TARGETS="gfx1151"` parameter in your cmake command with the a
 
 # For Strix Halo
 -DGPU_TARGETS="gfx1151"
+
+# For Krackan Point (Radeon 860M/840M in Ryzen AI 300 series)
+-DGPU_TARGETS="gfx1152"
 ```
 


### PR DESCRIPTION
## Summary
Enable nightly builds for the `gfx1152` target (Krackan Point). TheRock now publishes nightly tarballs for this target at `therock-nightly-tarball.s3.amazonaws.com` (`therock-dist-{windows,linux}-gfx1152-*.tar.gz`).


Related discussions: https://github.com/lemonade-sdk/llamacpp-rocm/issues/50