### PR TITLE
Require both Windows and Linux to pass when creating a release

### DIFF
--- a/.github/workflows/build-llamacpp-rocm.yml
+++ b/.github/workflows/build-llamacpp-rocm.yml
@@ -962,6 +962,8 @@ jobs:
       pull-requests: write
     if: |
       always() &&
+      (needs.build-windows.result == 'success' || needs.build-windows.result == 'skipped') &&
+      (needs.build-ubuntu.result == 'success' || needs.build-ubuntu.result == 'skipped') &&
       (needs.build-windows.result == 'success' || needs.build-ubuntu.result == 'success') &&
       (needs.test-stx-halo.result == 'success' || needs.test-stx-halo.result == 'skipped') &&
       (needs.test-stx.result == 'success' || needs.test-stx.result == 'skipped') &&


### PR DESCRIPTION
# Description

This PR changes the build gate so a release requires that neither platform failed, while still allowing an intentionally un-built OS (when someone runs workflow_dispatch with only windows or only ubuntu).