### PR TITLE
Fix Windows builds by fixing runner

### DIFF
--- a/.github/workflows/build-llamacpp-rocm.yml
+++ b/.github/workflows/build-llamacpp-rocm.yml
@@ -89,7 +89,11 @@ jobs:
         echo "Generated matrix: $matrix_targets"
 
   build-windows:
-    runs-on: windows-latest
+    # Pinned to windows-2022 (VS 2022 / MSVC 14.4x). The windows-latest image moved to
+    # VS 2026 (MSVC 14.51) on 2026-06-08, whose <cmath> declares isgreater/isless/etc. as
+    # constexpr (implicitly __host__ __device__), which collides with ROCm clang's
+    # __device__-only HIP math wrappers and breaks the HIP build. See llama.cpp#22570.
+    runs-on: windows-2022
     needs: prepare-matrix
     if: needs.prepare-matrix.outputs.should_build_windows == 'true'
     strategy:


### PR DESCRIPTION
# Description

This reverts the Windows builds to VS 2022 / MSVC 14.4x, which is compatible with the clang headers in the ROCm nightly. 

Once the clang/hipcc header fix lands in a ROCm nightly (tracked in [llama.cpp#22570](https://github.com/ggml-org/llama.cpp/issues/22570)), we could move back to windows-latest if we want the newer toolchain.

Related: https://github.com/ggml-org/llama.cpp/issues/22570

Closes https://github.com/lemonade-sdk/llamacpp-rocm/issues/113