### PR TITLE
Fix nightly ROCm auto-detection

### DIFF
--- a/.github/workflows/build-llamacpp-rocm.yml
+++ b/.github/workflows/build-llamacpp-rocm.yml
@@ -180,56 +180,53 @@ jobs:
         
         # Add appropriate suffixes for different GPU targets
         $s3Target = $currentTarget
-        if ($currentTarget -eq "gfx103X") {
-          $s3Target = "$currentTarget-dgpu"
-          Write-Host "Using S3 target with -dgpu suffix: $s3Target"
-        } elseif ($currentTarget -eq "gfx110X" -or $currentTarget -eq "gfx120X") {
+        if ($currentTarget -eq "gfx103X" -or $currentTarget -eq "gfx110X" -or $currentTarget -eq "gfx120X") {
           $s3Target = "$currentTarget-all"
-          Write-Host "Using S3 target with -all suffix: $s3Target"
+          Write-Host "Using target with -all suffix: $s3Target"
         }
         
+        # TheRock now publishes nightlies to the multi-arch tarball index. That
+        # index is a static HTML page with an embedded JSON `files` array (name +
+        # mtime), so we parse that instead of the retired S3 XML bucket listing.
+        $baseUrl = "https://rocm.nightlies.amd.com/tarball-multi-arch"
         if ($rocmVersion -eq "latest") {
           Write-Host "Auto-detecting latest ROCm version for target: $currentTarget"
-          $s3Response = (Invoke-WebRequest "https://therock-nightly-tarball.s3.amazonaws.com/?prefix=therock-dist-windows-$s3Target-7").Content
-          $files = $s3Response -split '<Key>' | Where-Object {$_ -match '</Key>'} | ForEach-Object { ($_ -split '</Key>')[0] }
-          
-          # Extract versions and sort them properly using semantic versioning
-          $versionFiles = @()
-          foreach ($file in $files) {
-            if ($file -match "therock-dist-windows-$s3Target-.*?(\d+\.\d+\.\d+(?:a|rc)\d+)\.tar\.gz") {
-              $version = $matches[1]
-              $versionFiles += [PSCustomObject]@{
-                File = $file
-                Version = $version
-                Major = [int]($version -split '\.')[0]
-                Minor = [int]($version -split '\.')[1]
-                Patch = [int](($version -split '\.')[2] -replace '(?:a|rc).*', '')
-                RC = [int]($version -replace '.*(?:a|rc)', '')
-                IsAlpha = $version -match 'a'
-              }
-            }
+          $indexHtml = (Invoke-WebRequest "$baseUrl/" -UseBasicParsing).Content
+          $filesMatch = [regex]::Match($indexHtml, 'const files = (\[.*?\]);', [System.Text.RegularExpressions.RegexOptions]::Singleline)
+          if (-not $filesMatch.Success) {
+            Write-Error "Failed to parse file index from $baseUrl/"
+            exit 1
           }
-          
-          # Sort by semantic version (major.minor.patch.rc, with alpha versions being newer than rc)
-          $latestFile = ($versionFiles | Sort-Object Major, Minor, Patch, @{Expression={if($_.IsAlpha){1}else{0}}}, RC | Select-Object -Last 1).File
-          
+
+          # Pick the newest by the YYYYMMDD build date embedded in the filename.
+          # Assign before piping so the parsed array enumerates element-by-element.
+          $allFiles = $filesMatch.Groups[1].Value | ConvertFrom-Json
+          $prefix = "therock-dist-windows-$s3Target-"
+          $latest = $allFiles |
+            Where-Object { $_.name -like "$prefix*" -and $_.name -match '\d{8}\.tar\.gz$' } |
+            Sort-Object { [regex]::Match($_.name, '(\d{8})\.tar\.gz$').Groups[1].Value } |
+            Select-Object -Last 1
+          if (-not $latest) {
+            Write-Error "No tarball found for prefix '$prefix' at $baseUrl/"
+            exit 1
+          }
+          $latestFile = $latest.name
           Write-Host "Found latest file: $latestFile"
-          
+
           # Extract version from the filename for environment variable
-          if ($latestFile -match "therock-dist-windows-$s3Target-.*?(\d+\.\d+\.\d+(?:a|rc)\d+)\.tar\.gz") {
+          if ($latestFile -match "therock-dist-windows-$s3Target-(\d+\.\d+\.\d+(?:a|rc)\d+)\.tar\.gz") {
             $rocmVersion = $matches[1]
             Write-Host "Detected latest ROCm version: $rocmVersion"
           } else {
             Write-Error "Failed to extract ROCm version from latest file: $latestFile"
-            Write-Error "Expected pattern: therock-dist-windows-$s3Target-*<version>.tar.gz"
+            Write-Error "Expected pattern: therock-dist-windows-$s3Target-<version>.tar.gz"
             exit 1
           }
-          
-          # Use the exact filename from S3 instead of reconstructing
-          $rocmUrl = "https://therock-nightly-tarball.s3.amazonaws.com/$latestFile"
+
+          $rocmUrl = "$baseUrl/$latestFile"
         } else {
-          # For specific versions, construct the URL as before
-          $rocmUrl = "https://therock-nightly-tarball.s3.amazonaws.com/therock-dist-windows-$s3Target-$rocmVersion.tar.gz"
+          # For specific versions, construct the URL directly
+          $rocmUrl = "$baseUrl/therock-dist-windows-$s3Target-$rocmVersion.tar.gz"
         }
         
         # Store the version for use in other steps
@@ -551,86 +548,48 @@ jobs:
         
         # Add appropriate suffixes for different GPU targets
         s3_target="$current_target"
-        if [ "$current_target" = "gfx103X" ]; then
-          s3_target="${current_target}-dgpu"
-          echo "Using S3 target with -dgpu suffix: $s3_target"
-        elif [[ "$current_target" = "gfx110X" || "$current_target" = "gfx120X" ]]; then
+        if [[ "$current_target" = "gfx103X" || "$current_target" = "gfx110X" || "$current_target" = "gfx120X" ]]; then
           s3_target="${current_target}-all"
-          echo "Using S3 target with -all suffix: $s3_target"
+          echo "Using target with -all suffix: $s3_target"
         fi
         
+        # TheRock now publishes nightlies to the multi-arch tarball index. That
+        # index is a static HTML page with an embedded JSON `files` array (name +
+        # mtime), so we parse that instead of the retired S3 XML bucket listing.
+        base_url="https://rocm.nightlies.amd.com/tarball-multi-arch"
         if [ "$rocm_version" = "latest" ]; then
           echo "Auto-detecting latest ROCm version for target: $current_target"
-          s3_response=$(curl -s "https://therock-nightly-tarball.s3.amazonaws.com/?prefix=therock-dist-linux-${s3_target}-7")
-          
-          # Extract all files and parse versions properly
-          files=$(echo "$s3_response" | grep -oP '(?<=<Key>)[^<]*' | grep "therock-dist-linux-${s3_target}-")
-          
-          # Extract versions and sort them properly using semantic versioning
-          latest_file=""
-          latest_major=0
-          latest_minor=0
-          latest_patch=0
-          latest_rc=0
-          latest_is_alpha=false
-          
-          while IFS= read -r file; do
-            if [[ "$file" =~ therock-dist-linux-${s3_target}-.*?([0-9]+\.[0-9]+\.[0-9]+(a|rc)[0-9]+)\.tar\.gz ]]; then
-              version="${BASH_REMATCH[1]}"
-              major=$(echo "$version" | cut -d. -f1)
-              minor=$(echo "$version" | cut -d. -f2)
-              patch=$(echo "$version" | cut -d. -f3 | sed 's/\(a\|rc\).*//')
-              rc=$(echo "$version" | sed 's/.*\(a\|rc\)//')
-              is_alpha=false
-              if [[ "$version" =~ a ]]; then
-                is_alpha=true
-              fi
-              
-              # Compare versions (alpha versions are newer than rc versions)
-              is_newer=false
-              if [ "$major" -gt "$latest_major" ]; then
-                is_newer=true
-              elif [ "$major" -eq "$latest_major" ] && [ "$minor" -gt "$latest_minor" ]; then
-                is_newer=true
-              elif [ "$major" -eq "$latest_major" ] && [ "$minor" -eq "$latest_minor" ] && [ "$patch" -gt "$latest_patch" ]; then
-                is_newer=true
-              elif [ "$major" -eq "$latest_major" ] && [ "$minor" -eq "$latest_minor" ] && [ "$patch" -eq "$latest_patch" ]; then
-                # Same major.minor.patch, compare alpha vs rc
-                if [ "$is_alpha" = true ] && [ "$latest_is_alpha" = false ]; then
-                  is_newer=true
-                elif [ "$is_alpha" = "$latest_is_alpha" ] && [ "$rc" -gt "$latest_rc" ]; then
-                  is_newer=true
-                fi
-              fi
-              
-              if [ "$is_newer" = true ]; then
-                latest_file="$file"
-                latest_major="$major"
-                latest_minor="$minor"
-                latest_patch="$patch"
-                latest_rc="$rc"
-                latest_is_alpha="$is_alpha"
-              fi
-            fi
-          done <<< "$files"
-          
+          prefix="therock-dist-linux-${s3_target}-"
+
+          files_json=$(curl -s "$base_url/" | tr '\n' ' ' | grep -oP 'const files = \K\[.*?\](?=\s*;)')
+          if [ -z "$files_json" ]; then
+            echo "Failed to parse file index from $base_url/"
+            exit 1
+          fi
+
+          # Pick the newest by the YYYYMMDD build date embedded in the filename.
+          latest_file=$(echo "$files_json" | jq -r --arg p "$prefix" \
+            '[.[] | select(.name | startswith($p)) | select(.name | test("[0-9]{8}\\.tar\\.gz$"))] | sort_by(.name | capture("(?<d>[0-9]{8})\\.tar\\.gz$").d) | last | .name // empty')
+          if [ -z "$latest_file" ]; then
+            echo "No tarball found for prefix '$prefix' at $base_url/"
+            exit 1
+          fi
           echo "Found latest file: $latest_file"
-          
+
           # Extract version from the filename for environment variable
-          if [[ "$latest_file" =~ therock-dist-linux-${s3_target}-.*?([0-9]+\.[0-9]+\.[0-9]+(a|rc)[0-9]+)\.tar\.gz ]]; then
+          if [[ "$latest_file" =~ therock-dist-linux-${s3_target}-([0-9]+\.[0-9]+\.[0-9]+(a|rc)[0-9]+)\.tar\.gz ]]; then
             rocm_version="${BASH_REMATCH[1]}"
             echo "Detected latest ROCm version: $rocm_version"
           else
             echo "Failed to extract ROCm version from latest file: $latest_file"
-            echo "Expected pattern: therock-dist-linux-${s3_target}-*<version>.tar.gz"
+            echo "Expected pattern: therock-dist-linux-${s3_target}-<version>.tar.gz"
             exit 1
           fi
-          
-          # Use the exact filename from S3 instead of reconstructing
-          rocm_url="https://therock-nightly-tarball.s3.amazonaws.com/$latest_file"
+
+          rocm_url="$base_url/$latest_file"
         else
-          # For specific versions, construct the URL as before
-          rocm_url="https://therock-nightly-tarball.s3.amazonaws.com/therock-dist-linux-${s3_target}-${rocm_version}.tar.gz"
+          # For specific versions, construct the URL directly
+          rocm_url="$base_url/therock-dist-linux-${s3_target}-${rocm_version}.tar.gz"
         fi
         
         # Store the version for use in other steps


### PR DESCRIPTION
# Description

TheRock retired the old `therock-nightly-tarball` S3 root (stuck at `2026-06-12`), so point detection at the new `rocm.nightlies.amd.com/tarball-multi-arch/ index`, parse its embedded JSON file list instead of S3 XML, and remap gfx103X to the `-all` suffix. Verified all 7 targets now resolve to the current nightly on both Linux and Windows.